### PR TITLE
Simplify metadata

### DIFF
--- a/lib/DataBuilder/GenericSOP.hs
+++ b/lib/DataBuilder/GenericSOP.hs
@@ -46,115 +46,115 @@ ci2RecordNames::ConstructorInfo xs -> Maybe (NP FieldInfo xs)
 ci2RecordNames (Record _ fi) = Just fi
 ci2RecordNames _ = Nothing
 
-ci2md::HasMetadata g=>g->DatatypeName->ConstructorInfo xs->K g xs
-ci2md mdh tn ci = K $ flip setConName (ci2name ci) . flip setTypeName tn $ mdh 
+ci2md::Metadata->DatatypeName->ConstructorInfo xs->K Metadata xs
+ci2md md tn ci = K $ setmConName (Just $ ci2name ci) . setTypeName tn $ md
 
-gAddMD::(HasMetadata g,SListI2 xss)=>g->DatatypeName->NP ConstructorInfo xss ->[g]
-gAddMD mdh tn cs = hcollapse $ hliftA (ci2md mdh tn) cs
+gAddMD::SListI2 xss=>Metadata->DatatypeName->NP ConstructorInfo xss ->[Metadata]
+gAddMD md tn cs = hcollapse $ hliftA (ci2md md tn) cs
 
 type GenericSOPC a = (Generic a, HasDatatypeInfo a)
-type BuildableC f g = (Buildable f g, HasMetadata g)
+--type BuildableC f = Buildable f 
 
-setFromFieldInfo::forall a g.HasMetadata g=>FieldInfo a->g->g
-setFromFieldInfo fi mdh = let (FieldInfo fName) = fi in setFieldName mdh fName
+setFromFieldInfo::forall a.FieldInfo a->Metadata->Metadata
+setFromFieldInfo fi md = let (FieldInfo fName) = fi in setmFieldName (Just fName) md
 
-setFromTypeName::forall g a.HasMetadata g=>K DatatypeName a->g->g
-setFromTypeName tn mdh = setTypeName mdh (unK tn)
+setFromTypeName::forall a.K DatatypeName a->Metadata->Metadata
+setFromTypeName tn md = setTypeName (unK tn) md
 
-setTypeAndFieldNames::forall g a.HasMetadata g=>K DatatypeName a->FieldInfo a->g->g
-setTypeAndFieldNames tn fi mdh = setFromFieldInfo fi (setFromTypeName tn mdh)
+setTypeAndFieldNames::forall a.K DatatypeName a->FieldInfo a->Metadata->Metadata
+setTypeAndFieldNames tn fi md = setFromFieldInfo fi . setFromTypeName tn $ md
 
-setmConName::forall a g.HasMetadata g=>Maybe ConName->g->g
-setmConName mcn mdh = setMetadata (Metadata (getTypeName $ getMetadata mdh) mcn (getmFieldName $ getMetadata mdh)) mdh
+--setmConName::forall a g.HasMetadata g=>Maybe ConName->g->g
+--setmConName mcn mdh = setMetadata (Metadata (getTypeName $ getMetadata mdh) mcn (getmFieldName $ getMetadata mdh)) mdh
 
-type MdwMap f g a = M.Map ConName (MDWrapped f g a)
+type MdwMap f a = M.Map ConName (MDWrapped f a)
 
-mdwMapToList::MdwMap f g a->[MDWrapped f g a]
+mdwMapToList::MdwMap f a->[MDWrapped f a]
 mdwMapToList = snd . unzip . M.toList
 
-mdwMapFromList::HasMetadata g=>[MDWrapped f g a]->MdwMap f g a
-mdwMapFromList mdws = M.fromList $ zip ((fromJust . getmConName) <$> mdws) mdws
+mdwMapFromList::[MDWrapped f a]->MdwMap f a
+mdwMapFromList mdws = M.fromList $ zip ((fromJust . conName . metadata) <$> mdws) mdws
 
-type GBuilderTopC f g a = (BuildableC f g, GenericSOPC a, All2 (Builder f g) (Code a), All2 HasDatatypeInfo (Code a))
+type GBuilderTopC f a = (Buildable f, GenericSOPC a, All2 (Builder f) (Code a), All2 HasDatatypeInfo (Code a))
 
-instance GBuilderTopC f g a=>GBuilder f g a where
-  gBuildM mdh ma = case ma of
-    Nothing -> internalSum $ buildBlanks mdh
-    Just x  -> let cn = fromJust (constructorName x) in internalSum . snd . unzip . M.toList $ M.insert cn (buildDefaulted mdh x) (buildBlankMap mdh)
+instance GBuilderTopC f a=>GBuilder f a where
+  gBuildM md ma = case ma of
+    Nothing -> internalSum $ buildBlanks md
+    Just x  -> let cn = fromJust (constructorName x) in internalSum . snd . unzip . M.toList $ M.insert cn (buildDefaulted md x) (buildBlankMap md)
 
-buildBlankMap::forall f g a.GBuilderTopC f g a => g->MdwMap f g a
+buildBlankMap::forall f a.GBuilderTopC f a => Metadata->MdwMap f a
 buildBlankMap = mdwMapFromList . buildBlanks
 
 
-buildBlanks::forall f g a.GBuilderTopC f g a => g->[MDWrapped f g a]
-buildBlanks mdh = 
+buildBlanks::forall f a.GBuilderTopC f a => Metadata->[MDWrapped f a]
+buildBlanks md = 
     let (tn,cs) = case datatypeInfo (Proxy :: Proxy a) of
           ADT _ tn cs -> (tn,cs)
           Newtype _ tn c -> (tn,(c :* Nil))
-        mdhs = gAddMD mdh tn cs
-        builders = (unFA . fmap to) <$> buildBlanks' mdh tn cs
-        mbs = zip mdhs builders
-        makeMDW (mdh',bldr) = MDWrapped False mdh' bldr
+        mds = gAddMD md tn cs
+        builders = (unFA . fmap to) <$> buildBlanks' md tn cs
+        mbs = zip mds builders
+        makeMDW (md',bldr) = MDWrapped False md' bldr
     in makeMDW <$> mbs
 
-type All2C f g xss = (All2 (Builder f g) xss, All2 HasDatatypeInfo xss)
-type GBuilderC2 f g xss = (BuildableC f g, All2C f g xss, SListI2 xss)
-buildBlanks'::forall f g xss.GBuilderC2 f g xss => g->DatatypeName->NP ConstructorInfo xss->[(FABuildable f) (SOP I xss)]
-buildBlanks' mdh tn cs =
+type All2C f xss = (All2 (Builder f) xss, All2 HasDatatypeInfo xss)
+type GBuilderC2 f xss = (Buildable f, All2C f xss, SListI2 xss)
+buildBlanks'::forall f xss.GBuilderC2 f xss => Metadata->DatatypeName->NP ConstructorInfo xss->[(FABuildable f) (SOP I xss)]
+buildBlanks' md tn cs =
   let dHNP = unAll_NP $ unAll2 Dict :: NP (Dict (All HasDatatypeInfo)) xss
-      allBuilder = Proxy :: Proxy (All (Builder f g))
-      pop = POP $ hcliftA2 allBuilder (\d->withDict d (buildBlank mdh tn)) dHNP cs
+      allBuilder = Proxy :: Proxy (All (Builder f))
+      pop = POP $ hcliftA2 allBuilder (\d->withDict d (buildBlank md tn)) dHNP cs
       wrapped = hliftA wrapBuildable pop -- POP (FABuildable f) xss
       sop = apInjs_POP wrapped -- [SOP (FABuildable f) xss]
   in hsequence <$> sop -- [(FABuildable f) (SOP I xss)]
 
 
-type GBuilderC1 f g xs  = (BuildableC f g, All (Builder f g) xs, All HasDatatypeInfo xs, SListI xs)
-buildBlank::forall f g xs.GBuilderC1 f g xs => g->DatatypeName->ConstructorInfo xs->NP f xs
+type GBuilderC1 f xs  = (Buildable f, All (Builder f) xs, All HasDatatypeInfo xs, SListI xs)
+buildBlank::forall f xs.GBuilderC1 f xs => Metadata->DatatypeName->ConstructorInfo xs->NP f xs
 buildBlank mdh tn ci = 
-    let mdhBase = setMetadata (Metadata tn (Just $ ci2name ci) Nothing) mdh
+    let mdBase = Metadata tn (Just $ ci2name ci) Nothing
         fieldNames = ci2RecordNames ci
         typeNames = gTypeNames :: NP (K DatatypeName) xs
-        builderC = Proxy :: Proxy (Builder f g)
+        builderC = Proxy :: Proxy (Builder f)
     in case fieldNames of 
            Nothing ->
-             let builder::Builder f g a=>K DatatypeName a -> f a
-                 builder tn = buildM (setFromTypeName tn mdhBase) Nothing
+             let builder::Builder f a=>K DatatypeName a -> f a
+                 builder tn = buildM (setFromTypeName tn mdBase) Nothing
              in hcliftA builderC builder typeNames
            Just fns -> 
-             let builder::Builder f g a=>FieldInfo a -> K DatatypeName a-> f a
-                 builder fi ktn = buildM (setTypeAndFieldNames ktn fi mdhBase) Nothing
+             let builder::Builder f a=>FieldInfo a -> K DatatypeName a-> f a
+                 builder fi ktn = buildM (setTypeAndFieldNames ktn fi mdBase) Nothing
              in hcliftA2 builderC builder fns typeNames
 
-buildDefaulted::forall f g a.GBuilderTopC f g a => g->a->MDWrapped f g a
-buildDefaulted mdh a =
+buildDefaulted::forall f a.GBuilderTopC f a => Metadata->a->MDWrapped f a
+buildDefaulted md a =
   let mcn = constructorName a
-      mdhBase = setmConName mcn mdh
-      allBuilder = Proxy :: Proxy (All (Builder f g))
+      mdBase = setmConName mcn md
+      allBuilder = Proxy :: Proxy (All (Builder f))
       dHNP = unAll_NP $ unAll2 Dict :: NP (Dict (All HasDatatypeInfo)) (Code a)
       (tn,cs) = case datatypeInfo (Proxy :: Proxy a) of
         ADT _ tn cs -> (tn,cs)
         Newtype _ tn c -> (tn,(c :* Nil))
-      sopf   = SOP $ hcliftA3 allBuilder (\d -> withDict d (buildDefFromConInfo mdhBase tn)) dHNP cs (unSOP $ from a) -- SOP f xss
+      sopf   = SOP $ hcliftA3 allBuilder (\d -> withDict d (buildDefFromConInfo mdBase tn)) dHNP cs (unSOP $ from a) -- SOP f xss
       sopFAf = hliftA wrapBuildable sopf                                                   -- SOP (FABuilder f) xss
       fa = unFA $ (fmap to) . hsequence $ sopFAf                                           -- f a
-  in MDWrapped True mdhBase fa
+  in MDWrapped True mdBase fa
 
 
-buildDefFromConInfo::forall f g xs.GBuilderC1 f g xs=>g->DatatypeName->ConstructorInfo xs->NP I xs->NP f xs
-buildDefFromConInfo mdh tn ci args =
-  let mdhBase = setMetadata (Metadata tn (Just $ ci2name ci) Nothing) mdh
+buildDefFromConInfo::forall f xs.GBuilderC1 f xs=>Metadata->DatatypeName->ConstructorInfo xs->NP I xs->NP f xs
+buildDefFromConInfo md tn ci args =
+  let mdBase = Metadata tn (Just $ ci2name ci) Nothing 
       fieldNames = ci2RecordNames ci
       typeNames = gTypeNames :: NP (K DatatypeName) xs
-      builderC = Proxy :: Proxy (Builder f g)
+      builderC = Proxy :: Proxy (Builder f)
   in case fieldNames of
       Nothing ->
-        let builder::Builder f g a=>K DatatypeName a -> I a -> f a
-            builder ktn ia = buildM (setFromTypeName ktn mdhBase) (Just $ unI ia)
+        let builder::Builder f a=>K DatatypeName a -> I a -> f a
+            builder ktn ia = buildM (setFromTypeName ktn mdBase) (Just $ unI ia)
         in hcliftA2 builderC builder typeNames args
       Just fns ->
-        let builder::Builder f g a=>FieldInfo a->K DatatypeName a->I a->f a
-            builder fi ktn ia = buildM (setTypeAndFieldNames ktn fi mdhBase) (Just (unI ia))
+        let builder::Builder f a=>FieldInfo a->K DatatypeName a->I a->f a
+            builder fi ktn ia = buildM (setTypeAndFieldNames ktn fi mdBase) (Just (unI ia))
         in hcliftA3 builderC builder fns typeNames args
 
 constructorName::forall a.GenericSOPC a=>a->Maybe ConName

--- a/lib/DataBuilder/InternalTypes.hs
+++ b/lib/DataBuilder/InternalTypes.hs
@@ -74,9 +74,17 @@ functionality.
 class Buildable f where
   -- so we can derive the functor instance of the wrapped version
   bMap::(a->b) -> f a->f b
+  default bMap::Functor f=>(a->b) -> f a -> f b
+  bMap = fmap
   -- inject and apply are exactly Applicative, inject=pure and apply=(<*>).
   bInject::a -> f a
+  default bInject::Applicative f=>a -> f a
+  bInject = pure
+
   bApply::f (a->b) -> f a -> f b
+  default bApply::Applicative f=>f (a->b) -> f a -> f b
+  bApply = (<*>)
+
   bFail::String->f a -- if there's a graceful way to handle errors...
   bSum::[MDWrapped f a]->f a -- used to decide how to represent a sum.  E.g., chooser in an HTML form
 

--- a/lib/DataBuilder/InternalTypes.hs
+++ b/lib/DataBuilder/InternalTypes.hs
@@ -111,7 +111,7 @@ internalSum::(HasMetadata g, Buildable f g)=>[MDWrapped f g a]->f a
 internalSum mdws = case length mdws of
   0 -> bFail "Internal error in DataBuilder.  No Constructors in Sum!"
   1 -> value (head mdws)
-  _ -> if buildersAllHaveConNames mdws then bSum mdws else bFail "Sum type for command encountered but constructor name(s) are missing."
+  _ -> if buildersAllHaveConNames mdws then bSum mdws else bFail "Sum type encountered but constructor name(s) are missing."
 
 
 newtype FABuildable f a = FABuildable { unFA::f a }

--- a/lib/DataBuilder/TH.hs
+++ b/lib/DataBuilder/TH.hs
@@ -38,6 +38,8 @@ typeShow :: Type -> Maybe String
 typeShow (ConT n) = Just $ toLower <$> nameBase n
 typeShow (VarT n) = Just $ toLower <$> nameBase n
 typeShow (TupleT n) = Just $ "tuple" ++ show n
+typeShow ListT = Just $ "[]"
+typeShow (AppT ListT t) = typeShow t >>= \x->Just ("listOf" ++ x) 
 typeShow (AppT t1 t2) = do
   ts1 <- typeShow t1
   ts2 <- typeShow t2

--- a/lib/DataBuilder/Types.hs
+++ b/lib/DataBuilder/Types.hs
@@ -4,10 +4,11 @@ module DataBuilder.Types
        , FieldName
        , ConName
        , Metadata(typeName,conName,fieldName)
+       , setTypeName
+       , setmConName
+       , setmFieldName
        , typeOnlyMD
-       , HasMetadata(..)
-       , HasMetadataFields(..)
-       , MDWrapped(hasDefault,metadataHolder,value)
+       , MDWrapped(hasDefault,metadata,value)
        , Buildable(..)
        , Builder(..)
        ) where

--- a/optionParser/Main.hs
+++ b/optionParser/Main.hs
@@ -28,25 +28,24 @@ instance HasDatatypeInfo Process
 data Commands = DoA {aFile::String} | DoB {bFile::String, bFlag::Bool} deriving (Show,GHCG.Generic)
 instance Generic Commands
 instance HasDatatypeInfo Commands
-instance Builder Parser OPBMDH Commands -- uses the generic version via generics-sop.  Requires SOP.Generic, SOP.HasDatatypeInfo
+instance Builder Parser Commands -- uses the generic version via generics-sop.  Requires SOP.Generic, SOP.HasDatatypeInfo
 
 data Config = Config {input :: String, output :: Maybe String, mode  :: Maybe Mode, process :: Process, cmd :: Commands  } deriving (Show,GHCG.Generic)
---deriveBuilder ''Parser ''OPBMDH ''Commands
+--deriveBuilder ''Parser ''Commands
 
 
-
+{-
 instance Generic Config
 instance HasDatatypeInfo Config
-instance Builder Parser OPBMDH Config -- uses the generic version via generics-sop.  Requires SOP.Generic, SOP.HasDatatypeInfo 
+instance Builder Parser Config -- uses the generic version via generics-sop.  Requires SOP.Generic, SOP.HasDatatypeInfo 
+-}
 
-
---deriveBuilder ''Parser ''OPBMDH ''Config --uses TH to build the instance.  Then you do not need the Generic or HasDatatypeInfo instances
+deriveOABuilder ''Config --uses TH to build the instance.  Then you do not need the Generic or HasDatatypeInfo instances
 
 
 main::IO ()
 main = (execParser $ info (helper <*> parser) infoMod) >>= print where
-  opbOptions = OPBOptions True
---  parser = buildM (typeOnlyOPBMDH opbOptions "Config") (Just $ configDefault) -- supplies defaults for everything
+--  parser = buildM (typeOnlyMD "Config") (Just $ configDefault) -- supplies defaults for everything
   configDefault = Config "Hello" Nothing (Just Verbose) AProcess
   infoMod = fullDesc <> progDesc "Sample use of DataBuilder to create a parser from a data type"
-  parser = buildM (typeOnlyOPBMDH opbOptions "Config") (Nothing :: Maybe Config) -- no defaults
+  parser = makeOAParser (Nothing :: Maybe Config) -- no defaults

--- a/optionParser/Main.hs
+++ b/optionParser/Main.hs
@@ -21,25 +21,26 @@ data Process = AProcess | BProcess deriving (Show,Enum,Bounded,GHCG.Generic)
 instance Generic Process
 instance HasDatatypeInfo Process
 
-data Config = Config {input :: String, output :: Maybe String, mode  :: Maybe Mode, process :: Process } deriving (Show,GHCG.Generic)
+--data Config = Config {input :: String, output :: Maybe String, mode  :: Maybe Mode, process :: Process } deriving (Show,GHCG.Generic)
 
 
-{- Also supports commands automatically if you derive the builder for a sum type
+-- Also supports commands automatically if you derive the builder for a sum type
 data Commands = DoA {aFile::String} | DoB {bFile::String, bFlag::Bool} deriving (Show,GHCG.Generic)
 instance Generic Commands
 instance HasDatatypeInfo Commands
+instance Builder Parser OPBMDH Commands -- uses the generic version via generics-sop.  Requires SOP.Generic, SOP.HasDatatypeInfo
 
 data Config = Config {input :: String, output :: Maybe String, mode  :: Maybe Mode, process :: Process, cmd :: Commands  } deriving (Show,GHCG.Generic)
-deriveBuilder ''Parser ''Commands
--}
+--deriveBuilder ''Parser ''OPBMDH ''Commands
+
 
 
 instance Generic Config
 instance HasDatatypeInfo Config
---instance Builder Parser OPBMDH Config -- uses the generic version via generics-sop.  Requires SOP.Generic, SOP.HasDatatypeInfo 
+instance Builder Parser OPBMDH Config -- uses the generic version via generics-sop.  Requires SOP.Generic, SOP.HasDatatypeInfo 
 
 
-deriveBuilder ''Parser ''OPBMDH ''Config --uses TH to build the instance.  Then you do not need the Generic or HasDatatypeInfo instances
+--deriveBuilder ''Parser ''OPBMDH ''Config --uses TH to build the instance.  Then you do not need the Generic or HasDatatypeInfo instances
 
 
 main::IO ()

--- a/optionParser/OptPABuilder.hs
+++ b/optionParser/OptPABuilder.hs
@@ -21,9 +21,7 @@ makeOAParser::Builder Parser a=>Maybe a->Parser a
 makeOAParser = buildM (typeOnlyMD "")
 
 instance Buildable Parser where
-  bMap = fmap 
-  bInject = pure 
-  bApply = (<*>)
+  -- the other instances handled by default since Parser is applicative
   bFail msg = abortOption (ErrorMsg msg) mempty <*> option disabled mempty
   bSum = sumToCommand
 

--- a/optionParser/OptPABuilder.hs
+++ b/optionParser/OptPABuilder.hs
@@ -5,32 +5,22 @@
 {-# LANGUAGE TemplateHaskell #-}
 module OptPABuilder
        (
-         OPBOptions(..)
-       , OPBMDH
-       , typeOnlyOPBMDH
-       , buildM
-       , deriveBuilder
+         makeOAParser
+       , deriveOABuilder
        ) where
 
 import DataBuilder.Types
 import Data.Maybe (fromJust)
 import Data.Char (toLower)
 import Options.Applicative
-import DataBuilder.TH (deriveBuilder)
+import DataBuilder.TH (deriveBuilder,handleNothingL,handleJustL)
+import Language.Haskell.TH
 
-data OPBOptions = OPBOptions { showDefaults::Bool }
-data OPBMDH = OPBMDH { options::OPBOptions, metadata::Metadata }
 
-typeOnlyOPBMDH::OPBOptions->TypeName->OPBMDH
-typeOnlyOPBMDH op tn = OPBMDH op (typeOnlyMD tn)
+makeOAParser::Builder Parser a=>Maybe a->Parser a
+makeOAParser = buildM (typeOnlyMD "")
 
-sdOption (OPBMDH op _) = if (showDefaults op) then showDefault else mempty
-
-instance HasMetadata OPBMDH where
-  getMetadata = metadata
-  setMetadata md' (OPBMDH op _) = OPBMDH op md' 
-
-instance Buildable Parser OPBMDH where
+instance Buildable Parser where
   bMap = fmap 
   bInject = pure 
   bApply = (<*>)
@@ -38,36 +28,42 @@ instance Buildable Parser OPBMDH where
   bSum = sumToCommand
 
 -- derive a command parser from a sum-type
-sumToCommand::[MDWrapped Parser OPBMDH a]->Parser a
+sumToCommand::[MDWrapped Parser a]->Parser a
 sumToCommand mdws =
-  let makeCommand mdw = command (fromJust $ getmConName mdw) (info (DataBuilder.Types.value mdw) mempty)
+  let makeCommand mdw = command (fromJust . conName . metadata $ mdw) (info (DataBuilder.Types.value mdw) mempty)
   in subparser $ mconcat (map makeCommand mdws)
 
 --shortAndLong::HasName f=>String->Mod f a
 shortAndLong x = long x <> short (head x)
 
-parseReadable::(Read a,Show a)=>ReadM a->Maybe String->OPBMDH->Maybe a->Parser a
-parseReadable reader mHelp opbmdh ma =
-  case (fieldName . getMetadata $ opbmdh) of
+parseReadable::(Read a,Show a)=>ReadM a->Maybe String->Metadata->Maybe a->Parser a
+parseReadable reader mHelp md ma =
+  case (fieldName md) of
     Nothing->argument reader ((maybe mempty Options.Applicative.value ma) <> (maybe mempty help mHelp))
-    Just fieldName -> option reader ((maybe mempty Options.Applicative.value ma) <> (shortAndLong fieldName) <> sdOption opbmdh <> (maybe mempty help mHelp))
+    Just fieldName -> option reader ((maybe mempty Options.Applicative.value ma) <> (shortAndLong fieldName) <> (maybe mempty help mHelp))
 
-instance Builder Parser OPBMDH Int where
+instance Builder Parser Int where
   buildM = parseReadable auto (Just "Int")
 
-instance Builder Parser OPBMDH Double where
+instance Builder Parser Double where
   buildM = parseReadable auto (Just "Double")
 
-instance Builder Parser OPBMDH String where
+instance Builder Parser String where
   buildM = parseReadable str (Just "String")
 
-instance {-# OVERLAPPABLE #-} (Show e,Enum e,Bounded e)=>Builder Parser OPBMDH e where
-  buildM opbmdh mE = foldl (<|>) empty $ map (\ev->fl ev (optDesc <> (shortAndLong (toLower <$> show ev)) <> sdOption opbmdh)) [minBound :: e..] where
+instance {-# OVERLAPPABLE #-} (Show e,Enum e,Bounded e)=>Builder Parser e where
+  buildM md mE = foldl (<|>) empty $ map (\ev->fl ev (optDesc <> (shortAndLong (toLower <$> show ev)))) [minBound :: e..] where
     fl = maybe flag' flag mE
-    optDesc = maybe mempty help (fieldName . getMetadata $ opbmdh) 
+    optDesc = maybe mempty help (fieldName md) 
 
-instance {-# OVERLAPPABLE #-} Builder Parser OPBMDH a=>Builder Parser OPBMDH (Maybe a) where
-  buildM opbmdh mmA = optional $ maybe (buildM opbmdh Nothing) (buildM opbmdh) mmA 
+instance {-# OVERLAPPABLE #-} Builder Parser a=>Builder Parser (Maybe a) where
+  buildM md mmA = optional $ maybe (buildM md Nothing) (buildM md) mmA 
+
+deriveOABuilder::Name -> Q [Dec]
+deriveOABuilder typeName = do
+  [d|instance Builder Parser $(conT typeName) where
+       buildM md Nothing  = $(handleNothingL typeName) md
+       buildM md (Just x) = $(handleJustL typeName) md x|]
 
 
 


### PR DESCRIPTION
Switched back to a simple metadata type as input to buildM.  More complex options are best carried via a ReaderT wrapper around the Builder.
